### PR TITLE
Added types for SVG tags

### DIFF
--- a/jsx.d.ts
+++ b/jsx.d.ts
@@ -556,13 +556,16 @@ declare namespace JSX {
     a: HtmlAnchorTag
     abbr: HtmlTag
     address: HtmlTag
+    animate: HtmlSvgTag
+    animateMotion: HtmlSvgTag
+    animateTransform: HtmlSvgTag
     area: HtmlAreaTag
     article: HtmlTag
     aside: HtmlTag
     audio: HtmlAudioTag
     b: HtmlTag
-    bb: HtmlBrowserButtonTag
     base: BaseTag
+    bb: HtmlBrowserButtonTag
     bdi: HtmlTag
     bdo: HtmlTag
     blockquote: HtmlQuoteTag
@@ -571,7 +574,9 @@ declare namespace JSX {
     button: HtmlButtonTag
     canvas: HtmlCanvasTag
     caption: HtmlTag
+    circle: HtmlSvgTag
     cite: HtmlTag
+    clipPath: HtmlSvgTag
     code: HtmlTag
     col: HtmlTableColTag
     colgroup: HtmlTableColTag
@@ -579,20 +584,50 @@ declare namespace JSX {
     data: DataTag
     datalist: HtmlDataListTag
     dd: HtmlTag
+    defs: HtmlSvgTag
     del: HtmlModTag
+    desc: HtmlSvgTag
     details: HtmlDetailsTag
     dfn: HtmlTag
     div: HtmlTag
     dl: HtmlTag
     dt: HtmlTag
+    ellipse: HtmlSvgTag
     em: HtmlTag
     embed: HtmlEmbedTag
+    feBlend: HtmlSvgTag
+    feColorMatrix: HtmlSvgTag
+    feComponentTransfer: HtmlSvgTag
+    feComposite: HtmlSvgTag
+    feConvolveMatrix: HtmlSvgTag
+    feDiffuseLighting: HtmlSvgTag
+    feDisplacementMap: HtmlSvgTag
+    feDistantLight: HtmlSvgTag
+    feDropShadow: HtmlSvgTag
+    feFlood: HtmlSvgTag
+    feFuncA: HtmlSvgTag
+    feFuncB: HtmlSvgTag
+    feFuncG: HtmlSvgTag
+    feFuncR: HtmlSvgTag
+    feGaussianBlur: HtmlSvgTag
+    feImage: HtmlSvgTag
+    feMerge: HtmlSvgTag
+    feMergeNode: HtmlSvgTag
+    feMorphology: HtmlSvgTag
+    feOffset: HtmlSvgTag
+    fePointLight: HtmlSvgTag
+    feSpecularLighting: HtmlSvgTag
+    feSpotLight: HtmlSvgTag
+    feTile: HtmlSvgTag
+    feTurbulence: HtmlSvgTag
     fieldset: HtmlFieldSetTag
     figcaption: HtmlTag
     figure: HtmlTag
+    filter: HtmlSvgTag
     footer: HtmlTag
+    foreignObject: HtmlSvgTag
     form: HtmlFormTag
-    hgroup: HtmlTag
+    g: HtmlSvgTag
     h1: HtmlTag
     h2: HtmlTag
     h3: HtmlTag
@@ -601,10 +636,12 @@ declare namespace JSX {
     h6: HtmlTag
     head: HtmlTag
     header: HtmlTag
+    hgroup: HtmlTag
     hr: HtmlTag
     html: HtmlHtmlTag
     i: HtmlTag
     iframe: HtmlIFrameTag
+    image: HtmlSvgTag
     img: HtmlImageTag
     input: HtmlInputTag
     ins: HtmlModTag
@@ -613,13 +650,19 @@ declare namespace JSX {
     label: HtmlLabelTag
     legend: HtmlLegendTag
     li: HtmlLITag
+    line: HtmlSvgTag
+    linearGradient: HtmlSvgTag
     link: HtmlLinkTag
     main: HtmlTag
     map: HtmlMapTag
     mark: HtmlTag
+    marker: HtmlSvgTag
+    mask: HtmlSvgTag
     menu: HtmlMenuTag
     meta: HtmlMetaTag
+    metadata: HtmlSvgTag
     meter: HtmlMeterTag
+    mpath: HtmlSvgTag
     nav: HtmlTag
     noscript: HtmlTag
     object: HtmlObjectTag
@@ -629,10 +672,16 @@ declare namespace JSX {
     output: HtmlOutputTag
     p: HtmlTag
     param: HtmlParamTag
+    path: HtmlSvgTag
+    pattern: HtmlSvgTag
+    polygon: HtmlSvgTag
+    polyline: HtmlSvgTag
     pre: HtmlTag
     progress: HtmlProgressTag
     q: HtmlQuoteTag
+    radialGradient: HtmlSvgTag
     rb: HtmlTag
+    rect: HtmlSvgTag
     rp: HtmlTag
     rt: HtmlTag
     rtc: HtmlTag
@@ -642,20 +691,27 @@ declare namespace JSX {
     script: HtmlScriptTag
     section: HtmlTag
     select: HtmlSelectTag
+    set: HtmlSvgTag
     small: HtmlTag
-    summary: HtmlTag
     source: HtmlSourceTag
     span: HtmlTag
+    stop: HtmlSvgTag
     strong: HtmlTag
     style: HtmlStyleTag
     sub: HtmlTag
+    summary: HtmlTag
     sup: HtmlTag
     svg: HtmlSvgTag
+    switch: HtmlSvgTag
+    symbol: HtmlSvgTag
     table: HtmlTableTag
+    tag: HtmlUnspecifiedTag
     tbody: HtmlTag
     td: HtmlTableDataCellTag
     template: HtmlTag
+    text: HtmlSvgTag
     textarea: HtmlTextAreaTag
+    textPath: HtmlSvgTag
     tfoot: HtmlTableSectionTag
     th: HtmlTableHeaderCellTag
     thead: HtmlTableSectionTag
@@ -663,11 +719,13 @@ declare namespace JSX {
     title: HtmlTag
     tr: HtmlTableRowTag
     track: HtmlTrackTag
+    tspan: HtmlSvgTag
     u: HtmlTag
     ul: HtmlTag
+    use: HtmlSvgTag
     var: HtmlTag
     video: HtmlVideoTag
+    view: HtmlSvgTag
     wbr: HtmlTag
-    tag: HtmlUnspecifiedTag
   }
 }


### PR DESCRIPTION
Added most of the SVG tags on https://developer.mozilla.org/en-US/docs/Web/SVG/Element, excluding deprecated ones