### PR TITLE
feat: add support for hotwire turbo elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 - [Migrating from HTML](#migrating-from-html)
   - [Base HTML templates](#base-html-templates)
   - [Htmx](#htmx)
+  - [Hotwire Turbo](#hotwire-turbo)
 - [Compiling HTML](#compiling-html)
   - [Clean Components](#clean-components)
 - [Fragments](#fragments)
@@ -330,6 +331,34 @@ const html = (
   <div hx-get="/api" hx-trigger="click" hx-target="#target">
     Click me!
   </div>
+)
+```
+
+<br />
+
+### Hotwire Turbo
+
+This project supports the usage of [Turbo Hotwire](https://turbo.hotwired.dev/). We provide a separate export
+that you can use to provide type definitions for the elements and attributes used with Turbo Hotwire.
+
+You just need to add this triple slash directive to the top of your file:
+
+```tsx
+/// <reference types="@kitajs/html/hotwire-turbo.d.ts" />
+
+import '@kitajs/html/register'
+
+const html = (
+  // Type checking and intellisense for all HTMX attributes
+  <turbo-frame id="messages">
+    <a href="/messages/expanded">
+      Show all expanded messages in this frame.
+    </a>
+
+    <form action="/messages">
+      Show response from this form within this frame.
+    </form>
+  </turbo-frame>
 )
 ```
 

--- a/hotwire-turbo.d.ts
+++ b/hotwire-turbo.d.ts
@@ -1,0 +1,131 @@
+// This file is a result from https://turbo.hotwired.dev/
+// Missing something? Please submit a issue report or a PR:
+// https://github.com/kitajs/html
+
+declare namespace JSX {
+  interface HtmlTag extends HotwireTurbo.Attributes {}
+  interface IntrinsicElements extends HotwireTurbo.Elements {}
+}
+
+declare namespace HotwireTurbo {
+  interface TurboFrameTag extends JSX.HtmlTag {
+    id: string;
+    /**
+     * Scroll to Turbo frame element after load
+     * Control the vertical alignment with data-autoscroll-block
+     */
+    autoscroll?: boolean;
+    target?: '_top' | Omit<string, '_top'>;
+    /**
+     * accepts a URL or path value that controls navigation of the element
+     */
+    src?: string;
+    /**
+     *  When loading="eager", changes to the src attribute will immediately navigate the element.
+     *  When loading="lazy", changes to the src attribute will defer navigation until the element is visible in the viewport.
+     *
+     *  @default {'eager'}
+     */
+    loading?: 'eager' | 'lazy';
+    /**
+     * Controls the autoscroll vertical alignment
+     * @link {https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#parameters}
+     * @default {'end'}
+     */
+    ['data-autoscroll-block']?: 'end' | 'start' | 'center' | 'nearest';
+    /**
+     * Controls the autoscroll behavior
+     * @link {https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#parameters}
+     * @default {'end'}
+     */
+    ['data-autoscroll-behavior']?: 'auto' | 'smooth';
+  }
+
+  interface TurboStreamTag extends JSX.HtmlTag {
+    action: 'append' | 'prepend' | 'replace' | 'update' | 'remove' | 'before' | 'after';
+    target?: string;
+    targets?: string;
+  }
+
+  interface Elements {
+    ['turbo-frame']: TurboFrameTag;
+    ['turbo-stream']: TurboStreamTag;
+  }
+
+  /**
+   * Turbo data attributes to add to every element
+   * This adds strong typing and documentation to these tags
+   */
+  interface Attributes {
+    /**
+     * false: disables Turbo Drive on links and forms including descendants.
+     * Use "true" to renable when an ancestor has opted out
+     */
+    ['data-turbo']?: 'true' | 'false';
+
+    /**
+     * tracks the element’s HTML and performs a full page reload when it changes
+    */
+    ['data-turbo-track']?: 'reload';
+
+    /**
+     * identifies the Turbo Frame to navigate.
+    */
+    ['data-turbo-frame']?: string;
+    /**
+     * Customizes the Turbo.visit action.
+     *
+     * "Replace" will visit a link without pushing a new history entry
+     * onto the stack. It will discard your current location in the history
+     * stack.
+    */
+    ['data-turbo-action']?: 'replace' | 'advance';
+    /**
+     * Persists element between page loads
+     *
+     * The element **must** have an id
+     *
+     * @link {https://turbo.hotwired.dev/handbook/building#persisting-elements-across-page-loads}
+    */
+    ['data-turbo-permanent']?: boolean;
+    /**
+     * Removes the element before the document is cached, preventing
+     * it from reappearing when restored.
+    */
+    ['data-turbo-temporary']?: boolean;
+    /**
+     * Prevents inline scripts from being re-evaluated on Visits.
+    */
+    ['data-turbo-eval']?: 'false'
+    /**
+     * Changes the request link method from the default "GET" request
+     * You should prefer a form in most cases
+    */
+    ['data-turbo-method']?: string;
+
+    /**
+     * Specifies that a link/form can accept a turbo stream response
+     *
+     * Turbo will automatically request Turbo streams on Form submissions for non GETs
+     *
+     * This is useful when trying to request turbo streams on GET requests
+    */
+    ['data-turbo-stream']?: boolean;
+    /**
+     * Presents a confirm dialog with the given value.
+     * This can be used on form elements or links with the data-turbo-method
+     * attribute.
+    */
+    ['data-turbo-confirm']?: string;
+    /**
+     * Specifies text to display when submitting a form. Can be used
+     * on input or button elements. While the form is submitting,
+     * the text of the element will show with this value.
+     *
+     * After submission, the original text will be restored.
+     *
+     * Useful for feedback like "Saving..." while an operation is in progress
+     */
+    ['data-turbo-submits-with']?: string;
+  }
+}

--- a/hotwire-turbo.js
+++ b/hotwire-turbo.js
@@ -1,0 +1,1 @@
+// No JS code is needed in this file. Its only here to allow direct import of hotwire-turbo.js

--- a/test/hotwire-turbo.test.tsx
+++ b/test/hotwire-turbo.test.tsx
@@ -1,0 +1,74 @@
+/// <reference types="../hotwire-turbo.d.ts" />
+//
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import Html from '../'
+
+describe('Turbo', () => {
+  it('should return turbo frames correctly', async () => {
+    assert.equal(
+      '<turbo-frame id="messages"></turbo-frame>',
+      <turbo-frame id="messages"></turbo-frame>
+    )
+
+    assert.equal(
+      '<turbo-frame id="messages"><a href="/messages/expanded">Show all expanded messages in this frame.</a><form action="/messages">Show response from this form within this frame.</form></turbo-frame>',
+      <turbo-frame id="messages">
+        <a href="/messages/expanded">
+          Show all expanded messages in this frame.
+        </a>
+
+        <form action="/messages">
+          Show response from this form within this frame.
+        </form>
+      </turbo-frame>
+
+    );
+
+    assert.equal(
+      '<turbo-frame id="messages" target="_top"><a href="/messages/1" data-turbo-frame="_self">Following link will replace just this frame.</a></turbo-frame>',
+      <turbo-frame id="messages" target="_top">
+        <a href="/messages/1" data-turbo-frame="_self">
+          Following link will replace just this frame.
+        </a>
+      </turbo-frame>
+    );
+
+    assert.equal(
+      '<turbo-frame id="messages" data-turbo-action="advance"><a href="/messages?page=2" data-turbo-action="replace">Replace history with next page</a></turbo-frame>',
+      <turbo-frame id="messages" data-turbo-action="advance">
+        <a href="/messages?page=2" data-turbo-action="replace">Replace history with next page</a>
+      </turbo-frame>
+    );
+  })
+
+  it('should render turbo streams correctly', async () => {
+    assert.equal(
+      '<turbo-stream action="append" target="dom_id"><template>Content to append to container designated with the dom_id.</template></turbo-stream>',
+      <turbo-stream action="append" target="dom_id">
+        <template>
+          Content to append to container designated with the dom_id.
+        </template>
+      </turbo-stream>
+    )
+
+    assert.equal(
+      '<turbo-stream action="prepend" target="dom_id"><template>Content to prepend to container designated with the dom_id.</template></turbo-stream>',
+      <turbo-stream action="prepend" target="dom_id">
+        <template>
+          Content to prepend to container designated with the dom_id.
+        </template>
+      </turbo-stream>
+    )
+
+    assert.equal(
+      '<turbo-stream action="replace" target="dom_id"><template>Content to replace the element designated with the dom_id.</template></turbo-stream>',
+      <turbo-stream action="replace" target="dom_id">
+        <template>
+          Content to replace the element designated with the dom_id.
+        </template>
+      </turbo-stream>
+    )
+  })
+})
+


### PR DESCRIPTION
This PR adds typed support for the `<turbo-frame>` and `<turbo-stream>` elements and strongly typed support for the other related Turbo data attributes to all the elements.

Resolves #29 