### PR TITLE
Add hyperscript tag

### DIFF
--- a/htmx.d.ts
+++ b/htmx.d.ts
@@ -513,5 +513,12 @@ declare namespace Htmx {
      * @see https://htmx.org/extensions/head-support/
      */
     ['hx-head']?: 'merge' | 'append' | 're-eval';
+
+    /**
+     * Hyperscript expression
+     *
+     * @see https://hyperscript.org/
+     */
+    _?: string;
   }
 }


### PR DESCRIPTION
I guess that hyperscript is technically an add-on to HTMX, so you might not want this in the core htmx type definition, but I thought it might still be helpful.