### PR TITLE
Fix for `style` prop type. Resolves #60.

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ function styleToString(style) {
   const keys = Object.keys(style);
   const length = keys.length;
 
-  let key, value, end, start, type;
+  let key, value, end, start;
   let index = 0;
   let result = '';
 
@@ -169,51 +169,44 @@ function styleToString(style) {
     key = keys[index];
     // @ts-expect-error - this indexing is safe.
     value = style[key];
-    type = typeof value;
 
-    if (type === 'string') {
-      end = value.indexOf('"');
+    if (value === null || value === undefined) {
+      continue;
+    }
 
-      // This is a optimization to avoid having to look twice for the " character.
-      // And make the loop already start in the middle
-      if (end === -1) {
-        // @ts-expect-error - this indexing is safe.
-        result += toKebabCase(key) + ':' + value + ';';
-        continue;
-      } else {
-        // @ts-expect-error - this indexing is safe.
-        result += toKebabCase(key) + ':';
+    // @ts-expect-error - this indexing is safe.
+    result += toKebabCase(key) + ':';
+
+    // Only needs escaping when the value is a string.
+    if (typeof value !== 'string') {
+      result += value.toString() + ';';
+      continue;
+    }
+
+    end = value.indexOf('"');
+
+    // This is a optimization to avoid having to look twice for the " character.
+    // And make the loop already start in the middle
+    if (end === -1) {
+      result += value + ';';
+      continue;
+    }
+
+    const length = value.length;
+    start = 0;
+
+    // Escapes double quotes to be used inside attributes
+    // Faster than using regex
+    // https://jsperf.app/kakihu
+    for (; end < length; end++) {
+      if (value[end] === '"') {
+        result += value.slice(start, end) + '&#34;';
+        start = end + 1;
       }
-
-      const length = value.length;
-      start = 0;
-
-      // Escapes double quotes to be used inside attributes
-      // Faster than using regex
-      // https://jsperf.app/kakihu
-      for (; end < length; end++) {
-        if (value[end] === '"') {
-          result += value.slice(start, end) + '&#34;';
-          start = end + 1;
-        }
-      }
-
-      // Appends the remaining string.
-      result += value.slice(start, end) + ';';
-      continue;
     }
 
-    if (type === 'number') {
-      // @ts-expect-error - this indexing is safe.
-      result += toKebabCase(key) + ':' + value + (value === 0 ? ';' : 'px;');
-      continue;
-    }
-
-    if (type === 'object' && value !== null) {
-      // @ts-expect-error - this indexing is safe.
-      result += toKebabCase(key) + ':' + value.toString() + ';';
-      continue;
-    }
+    // Appends the remaining string.
+    result += value.slice(start, end) + ';';
   }
 
   return result;
@@ -383,7 +376,7 @@ function createElement(name, attrs, ...children) {
 
   // Calls the element creator function if the name is a function
   if (typeof name === 'function') {
-    // We at least need to pass the children to the function component. We may receive null if this
+    // We at least need to pass the children to the function component. We may receive null if this 
     // component was called without any children.
     if (!hasAttrs) {
       attrs = { children: children.length > 1 ? children : children[0] };

--- a/jsx.d.ts
+++ b/jsx.d.ts
@@ -26,7 +26,7 @@ declare namespace JSX {
    * For examples and more information, visit:
    * https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors
    */
-  type CSSProperties = import('csstype').Properties<string | number | boolean>;
+  type CSSProperties = import('csstype').Properties;
 
   interface HtmlTag extends ElementChildrenAttribute, IntrinsicAttributes {
     accesskey?: undefined | string;

--- a/test/style.test.tsx
+++ b/test/style.test.tsx
@@ -25,21 +25,6 @@ describe('Style', () => {
     assert.equal(<div style={style} />, '<div style="color:red;not:defined;"></div>');
   });
 
-  test('Same behavior as react', () => {
-    assert.equal(
-      <div
-        style={{
-          height: false,
-          width: true,
-          maxWidth: 123,
-          maxHeight: 0,
-          minWidth: '12a3'
-        }}
-      ></div>,
-      <div style="max-width:123px;max-height:0;min-width:12a3;"></div>
-    );
-  });
-
   test('Weird values', () => {
     assert.equal(
       styleToString({
@@ -47,22 +32,9 @@ describe('Style', () => {
         b: undefined,
         c: 1,
         d: '2',
-        e: { f: 3 },
-        f: null,
-        g: true,
-        h: false,
-        i: NaN,
-        j: Infinity,
-        k: -Infinity,
-        l: '',
-        m: ' ',
-        n: [],
-        o: [1, 2, 3],
-        p: {},
-        q: { a: 1, b: 2, c: 3 }
+        e: { f: 3 }
       }),
-      // Similar behavior to react
-      'a:0;c:1px;d:2;e:[object Object];i:NaNpx;j:Infinitypx;k:-Infinitypx;l:;m: ;n:;o:1,2,3;p:[object Object];q:[object Object];'
+      'a:0;c:1;d:2;e:[object Object];'
     );
   });
 });


### PR DESCRIPTION
Hi @arthurfiorette, thanks again for your prompt attention to the `style` prop issue.

I went ahead and created a revert commit for your patch, since we determined that it would be better to avoid the complexity of implicitly adding the `px` for now.

Instead, all we're doing here is making the `CSSProperties` type a bit more restrictive in order to line up with the existing behavior. Removing the generic argument just means that the various "length" properties (think `width`, `font-size`, `margin`, etc.) won't accept number values other than `0` (which doesn't require a unit to be specified).