### PR TITLE
supporting attrs to escape : or . attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -264,6 +264,16 @@ function attributesToString(attributes) {
     } else if (key === 'style') {
       result += ' style="' + styleToString(value) + '"';
       continue;
+    } else if (key === 'attrs') {
+      const regexAttributes = /\s*(\S+)=["']([^"']+)["']|\s*(\S+)=([^&\s]+)\s*/g
+      let resultAttrs = '';
+      let match;
+      while ((match = regexAttributes.exec(value)) !== null) {
+        const [_, attribute, value] = match;
+        resultAttrs += " " + attribute + "=\"" + value + "\"";
+      };
+      result += resultAttrs ;
+      continue;
     }
 
     type = typeof value;
@@ -466,11 +476,10 @@ function compile(htmlFn, strict = true, separator = '/*\x00*/') {
           }
 
           // Uses ` to avoid content being escaped.
-          return `\`${separator} + (${access} || ${
-            strict && !isChildren
+          return `\`${separator} + (${access} || ${strict && !isChildren
               ? `throwPropertyNotFound(${separator}\`${name.toString()}\`${separator})`
               : `${separator}\`\`${separator}`
-          }) + ${separator}\``;
+            }) + ${separator}\``;
         }
       }
     )

--- a/jsx.d.ts
+++ b/jsx.d.ts
@@ -41,7 +41,7 @@ declare namespace JSX {
     tabindex?: undefined | number | string;
     title?: undefined | string;
     translate?: undefined | string | boolean;
-
+    attrs?: undefined | string;
     /** A css style attribute which also supports a `csstype` object. */
     style?: undefined | string | CSSProperties;
 

--- a/test/attributes.test.tsx
+++ b/test/attributes.test.tsx
@@ -76,4 +76,11 @@ describe('Attributes', () => {
       '<div class="a b c d f g h i j"></div>'
     );
   });
+
+  test('attrs property', () => {
+    assert.equal(
+      <div attrs={`x-transition:enter="transition ease-out duration-30" x-test.ing="fn"`} />,
+      '<div x-transition:enter="transition ease-out duration-30" x-test.ing="fn"></div>'
+    );
+  })
 });


### PR DESCRIPTION
related with issue supporting[ . (dot) and : (colon) syntax](https://github.com/kitajs/html/issues/97#issuecomment-1899658919) to add support with string. Added one test case to make sure it work and it passed. 

However, I had issue with TS where the TS Language not reading attrs in HtmlTag ,can anyone review / improve this ? thank you