### PR TITLE
docs: add section `no context api`

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,6 @@ function SomeLayoutPage(
 
 function SubMenu(props: { user?: User }) {
   // do thing with the user, maybe check if the user is logged in
-  const isLoggedIn = !!props.user;
   return <nav>...</nav>;
 }
 

--- a/README.md
+++ b/README.md
@@ -564,7 +564,6 @@ function SubMenu(props: { user?: User }) {
 }
 
 // Example Request handler using the above components
-
 app.get('/', (request, response) => {
   response.send(
     <Doctype title="Home" head={<link rel="stylesheet" href="/style.css" />}>

--- a/README.md
+++ b/README.md
@@ -533,7 +533,6 @@ function Doctype(props: Html.PropsWithChildren<{ head: JSX.Element; title?: stri
       {'<!doctype html>'}
       <html lang="en">
         <head>
-          <meta charset="UTF-8" />
           <title>{props.title || 'Hello World!'}</title>
         </head>
         <body>{props.children}</body>

--- a/README.md
+++ b/README.md
@@ -534,7 +534,6 @@ function Doctype(props: Html.PropsWithChildren<{ head: JSX.Element; title?: stri
       <html lang="en">
         <head>
           <meta charset="UTF-8" />
-          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
           <title>{props.title || 'Hello World!'}</title>
           {props.head}
         </head>

--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ function SubMenu(props: { user?: User }) {
 // Example Request handler using the above components
 app.get('/', (request, response) => {
   response.send(
-    <Doctype title="Home" head={<link rel="stylesheet" href="/style.css" />}>
+    <Doctype title="Home">
       <SomeLayoutPage
         leftSection={<SubMenu url={request.url} />}
         topSection={<YourNavbar user={request.user} />}

--- a/README.md
+++ b/README.md
@@ -563,7 +563,7 @@ function SubMenu(props: { user?: User }) {
 
 // Example Request handler using the above components
 app.get('/', (request, response) => {
-  response.send(
+  response.html(
     <Doctype title="Home">
       <SomeLayoutPage
         leftSection={<SubMenu url={request.url} />}

--- a/README.md
+++ b/README.md
@@ -526,7 +526,6 @@ composition style of writing components. This is a common pattern in other JSX-b
 libraries, and it works well with this library too.
 
 ```tsx
-// Layout.tsx
 function Doctype(props: Html.PropsWithChildren<{ head: JSX.Element; title?: string }>) {
   return (
     <>

--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ context in the first place. The `rid` is needed to make the context async safe.
 
 The only way to maintain data consistency across concurrent renders without attaching a
 request locator (`rid`), is by using
-(ALS)[https://nodejs.org/api/async_context.html#class-asynclocalstorage]. However, this
+[ALS](https://nodejs.org/api/async_context.html#class-asynclocalstorage). However, this
 approach introduces a lot of overhead and a significant performance penalty.
 
 Our recommendation is to use props. If you want to avoid prop drilling, you can use a

--- a/README.md
+++ b/README.md
@@ -526,50 +526,16 @@ composition style of writing components. This is a common pattern in other JSX-b
 libraries, and it works well with this library too.
 
 ```tsx
-function Doctype(props: Html.PropsWithChildren<{ head: JSX.Element; title?: string }>) {
-  return (
-    <>
-      {'<!doctype html>'}
-      <html lang="en">
-        <head>
-          <title>{props.title || 'Hello World!'}</title>
-        </head>
-        <body>{props.children}</body>
-      </html>
-    </>
-  );
-}
-
-function SomeLayoutPage(
-  props: Html.PropsWithChildren<{ leftSection: JSX.Element; topSection: JSX.Element }>
-) {
-  return (
-    <div>
-      <div>{props.topSection}</div>
-      <div>{props.leftSection}</div>
-      <div>{props.children}</div>
-    </div>
-  );
-}
-
-function SubMenu(props: { user?: User }) {
-  // do thing with the user, maybe check if the user is logged in
-  return <nav>{props.user ? 'Logged in' : 'Logged out'}</nav>;
-}
-
-// Example Request handler using the above components
-app.get('/', (request, response) => {
-  return (
-    <Doctype title="Home">
-      <SomeLayoutPage
-        leftSection={<SubMenu url={request.url} />}
-        topSection={<YourNavbar user={request.user} />}
-      >
-        <div>Home page</div>
-      </SomeLayoutPage>
-    </Doctype>
-  );
-});
+// Drills only the required properties.
+app.get('/', (request, response) => (
+  <YourDoctype title="Home">
+    <YourLayout loggedIn={!!request.user} lang={request.headers['accept-language']}>
+      <YourNavbar user={request.user} />
+      <YourContent />
+      <YourSubMenu path={request.url} username={request.user?.name} />
+    </YourLayout>
+  </YourDoctype>
+));
 ```
 
 </br>

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ function SomeLayoutPage(
 
 function SubMenu(props: { user?: User }) {
   // do thing with the user, maybe check if the user is logged in
-  return <nav>...</nav>;
+  return <nav>{props.user ? 'Logged in' : 'Logged out'}</nav>;
 }
 
 // Example Request handler using the above components

--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ function SubMenu(props: { user?: User }) {
 
 // Example Request handler using the above components
 app.get('/', (request, response) => {
-  response.html(
+  return (
     <Doctype title="Home">
       <SomeLayoutPage
         leftSection={<SubMenu url={request.url} />}

--- a/README.md
+++ b/README.md
@@ -535,7 +535,6 @@ function Doctype(props: Html.PropsWithChildren<{ head: JSX.Element; title?: stri
         <head>
           <meta charset="UTF-8" />
           <title>{props.title || 'Hello World!'}</title>
-          {props.head}
         </head>
         <body>{props.children}</body>
       </html>

--- a/README.md
+++ b/README.md
@@ -527,7 +527,6 @@ libraries, and it works well with this library too.
 
 ```tsx
 // Layout.tsx
-
 function Doctype(props: Html.PropsWithChildren<{ head: JSX.Element; title?: string }>) {
   return (
     <>


### PR DESCRIPTION
Add some documentation to explain why there is no context API.

Related: https://github.com/kitajs/html/issues/107