### PR TITLE
feat: add escape tagged function to escape html

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ issues in your code editor and enhance your code's security.
 This package sanitizes every attribute by default. However, since the resulting element is
 always a string, it's impossible to differentiate an HTML element created by a `<tag>` or
 from user input. This necessitates the use of the provided [`safe`](#the-safe-attribute)
-or manual invocation of `Html.escapeHtml`. Or you can also use the `Html.escape` template
-function.
+or manual invocation of `Html.escapeHtml`. Or you can also use the `Html.escape` or its
+alias `e` template function.
 
 ```tsx
 <div>⚠️ This will NOT be escaped and WILL expose you to XSS</div>
@@ -212,14 +212,17 @@ function.
 <div>{Html.escapeHtml('This WILL be escaped')}</div>
 ```
 
-or using the `Html.escape` template function:
+or using the `Html.escape` or its alias `e` template function:
 
 ```tsx
+import { e } from '@kitajs/html';
+
 <div>⚠️ This will NOT be escaped and WILL expose you to XSS</div>
 
 <div attr="This WILL be escaped"></div>
 <div safe>This WILL be escaped</div>
 <div>{Html.escape`This WILL be escaped`}</div>
+<div>{e`This WILL be escaped`}</div>
 ```
 
 Here's an example of how this is **DANGEROUS** for your application:

--- a/README.md
+++ b/README.md
@@ -201,7 +201,8 @@ issues in your code editor and enhance your code's security.
 This package sanitizes every attribute by default. However, since the resulting element is
 always a string, it's impossible to differentiate an HTML element created by a `<tag>` or
 from user input. This necessitates the use of the provided [`safe`](#the-safe-attribute)
-or manual invocation of `Html.escapeHtml`.
+or manual invocation of `Html.escapeHtml`. Or you can also use the `Html.escape` template
+function.
 
 ```tsx
 <div>⚠️ This will NOT be escaped and WILL expose you to XSS</div>
@@ -209,6 +210,16 @@ or manual invocation of `Html.escapeHtml`.
 <div attr="This WILL be escaped"></div>
 <div safe>This WILL be escaped</div>
 <div>{Html.escapeHtml('This WILL be escaped')}</div>
+```
+
+or using the `Html.escape` template function:
+
+```tsx
+<div>⚠️ This will NOT be escaped and WILL expose you to XSS</div>
+
+<div attr="This WILL be escaped"></div>
+<div safe>This WILL be escaped</div>
+<div>{Html.escape`This WILL be escaped`}</div>
 ```
 
 Here's an example of how this is **DANGEROUS** for your application:

--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -37,8 +37,6 @@ assert.equal(
     .join('')
 );
 
-
-
 // Ensures that Kitajs/html and ghtml produce the same output
 assert.equal(
   ManyComponents(KitaHtml, 'Hello World!'),

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,20 @@
 export function isUpper(this: void, input: string, index: number): boolean;
 
 /**
+ * Tag function that escapes the given string pieces and interpolates the given values.
+ * Internally it uses {@linkcode escapeHtml} to escape the values.
+ *
+ * @param {TemplateStringsArray} the Template string.
+ * @returns {string} The escaped string.
+ * @this {void}
+ */
+export function escape(
+  this: void,
+  strPieces: TemplateStringsArray,
+  ...values: Array<any>
+): string;
+
+/**
  * Escapes a string for safe use as HTML text content. If the value is not a string, it is
  * coerced to one with its own `toString()` method.
  *

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,14 +16,15 @@ export function isUpper(this: void, input: string, index: number): boolean;
  * Tag function that escapes the given string pieces and interpolates the given values.
  * Internally it uses {@linkcode escapeHtml} to escape the values.
  *
- * @param {TemplateStringsArray} the Template string.
+ * @param {TemplateStringsArray} strings Template string.
+ * @param {...any} values Values to interpolate.
  * @returns {string} The escaped string.
  * @this {void}
  */
 export function escape(
   this: void,
-  strPieces: TemplateStringsArray,
-  ...values: Array<any>
+  strings: TemplateStringsArray,
+  ...values: any[]
 ): string;
 
 /**
@@ -160,6 +161,19 @@ export function compile<
 
 /** Here for interop with `preact` and many build systems. */
 export const h: typeof createElement;
+
+/**
+ * Alias of {@linkcode escape} to reduce verbosity.
+ *
+ * @example
+ *
+ * ```tsx
+ * import { e } from '@kitajs/html'
+ *
+ * <div>{e`My name is ${user.name}!`}</div>;
+ * ```
+ */
+export const e: typeof escape;
 
 /**
  * A JSX Fragment is used to return multiple elements from a component.

--- a/index.js
+++ b/index.js
@@ -47,14 +47,24 @@ function toKebabCase(camel) {
 }
 
 /** @type {import('.').escape} */
-function escape(strPieces, ...values) {
-  return strPieces.reduce(function (result, strPiece, index) {
-    let correspondingValue = values[index];
-    if (correspondingValue === undefined) {
-      return result + escapeHtml(strPiece);
+function escape(strings, ...values) {
+  const stringsLength = strings.length;
+  const valuesLength = values.length;
+
+  let index = 0;
+  let result = '';
+
+  for (; index < stringsLength; index++) {
+    result += strings[index];
+
+    if (index < valuesLength) {
+      result += values[index];
     }
-    return result + escapeHtml(strPiece) + escapeHtml(correspondingValue);
-  }, '');
+  }
+
+  // Escape the entire string at once.
+  // This is faster than escaping each piece individually.
+  return escapeHtml(result);
 }
 
 /** @type {import('.').escapeHtml} */
@@ -546,6 +556,7 @@ function compile(htmlFn, strict = true, separator = '/*\x00*/') {
 
 const Html = {
   escape,
+  e: escape,
   escapeHtml,
   isVoidElement,
   attributesToString,

--- a/index.js
+++ b/index.js
@@ -46,6 +46,17 @@ function toKebabCase(camel) {
   return kebab;
 }
 
+/** @type {import('.').escape} */
+function escape(strPieces, ...values) {
+  return strPieces.reduce(function (result, strPiece, index) {
+    let correspondingValue = values[index];
+    if (correspondingValue === undefined) {
+      return result + escapeHtml(strPiece);
+    }
+    return result + escapeHtml(strPiece) + escapeHtml(correspondingValue);
+  }, '');
+}
+
 /** @type {import('.').escapeHtml} */
 let escapeHtml = function (value) {
   if (typeof value !== 'string') {
@@ -534,6 +545,7 @@ function compile(htmlFn, strict = true, separator = '/*\x00*/') {
 }
 
 const Html = {
+  escape,
   escapeHtml,
   isVoidElement,
   attributesToString,

--- a/test/escape-tagged-func.test.tsx
+++ b/test/escape-tagged-func.test.tsx
@@ -1,0 +1,197 @@
+import assert from 'node:assert';
+import test, { describe } from 'node:test';
+import Html from '../index';
+
+const unsafeTag = '<script tag="1">alert(1)</script>';
+const safeTag = Html.escape`${unsafeTag}`;
+
+describe('HTML Escaping', () => {
+  test('escapes content', () => {
+    assert.equal(<>{unsafeTag}</>, <>{unsafeTag}</>);
+  });
+
+  test('with children', () => {
+    assert.equal(
+      <>
+        <div>{unsafeTag}</div>
+      </>,
+      <>
+        <div>{unsafeTag}</div>
+      </>
+    );
+  });
+
+  test('escapes children', () => {
+    assert.equal(
+      <>
+        <div safe>{unsafeTag}</div>
+      </>,
+      <>
+        <div>{safeTag}</div>
+      </>
+    );
+  });
+
+  test('escapes deep children', () => {
+    assert.equal(
+      <>
+        <div safe>
+          <div>{unsafeTag}</div>
+        </div>
+      </>,
+      <>
+        <div>{Html.escape`${(<div>{unsafeTag}</div>)}`}</div>
+      </>
+    );
+  });
+
+  test('always escapes attributes', () => {
+    assert.equal(
+      <>
+        <div style={'"&<>\''}></div>
+        <div style={{ backgroundColor: '"&<>\'' }}></div>
+        <div class={'"&<>\''}></div>
+        <div class={'test:1" xss="false'}></div>
+      </>,
+      <>
+        <div style="&#34;&<>'"></div>
+        <div style="background-color:&#34;&<>';"></div>
+        <div class="&#34;&<>'"></div>
+        <div class="test:1&#34; xss=&#34;false"></div>
+      </>
+    );
+
+    assert.equal(
+      <>
+        <div style={`"&<>'`}></div>
+        <div style={{ backgroundColor: `"&<>'` }}></div>
+        <div class={`"&<>'`}></div>
+      </>,
+      `<div style="&#34;&<>'"></div><div style="background-color:&#34;&<>';"></div><div class="&#34;&<>'"></div>`
+    );
+  });
+
+  test('handles unknown values', () => {
+    assert.equal(Html.escape``, '');
+    assert.equal(Html.escape`${{ a: 1 }}`, '[object Object]');
+  });
+
+  // The matrix of cases we need to test for:
+  // 1. Works with short strings
+  // 2. Works with long strings
+  // 3. Works with latin1 strings
+  // 4. Works with utf16 strings
+  // 5. Works when the text to escape is somewhere in the middle
+  // 6. Works when the text to escape is in the beginning
+  // 7. Works when the text to escape is in the end
+  // 8. Returns the same string when there's no need to escape
+  test('always escape', () => {
+    assert.equal(
+      Html.escape`absolutely nothing to do here`,
+      'absolutely nothing to do here'
+    );
+    assert.equal(
+      Html.escape`<script>alert(1)</script>`,
+      '&lt;script>alert(1)&lt;/script>'
+    );
+    assert.equal(Html.escape`<`, '&lt;');
+    assert.equal(Html.escape`>`, '>');
+    assert.equal(Html.escape`&`, '&amp;');
+    assert.equal(Html.escape`'`, '&#39;');
+    assert.equal(Html.escape`"`, '&#34;');
+    assert.equal(Html.escape`\u00A0`, '\u00A0');
+    assert.equal(Html.escape`<script>ab`, '&lt;script>ab');
+    assert.equal(Html.escape`<script>`, '&lt;script>');
+    assert.equal(Html.escape`<script><script>`, '&lt;script>&lt;script>');
+
+    assert.equal(
+      Html.escape`lalala<script>alert(1)</script>lalala`,
+      'lalala&lt;script>alert(1)&lt;/script>lalala'
+    );
+
+    assert.equal(
+      Html.escape`<script>alert(1)</script>lalala`,
+      '&lt;script>alert(1)&lt;/script>lalala'
+    );
+    assert.equal(
+      Html.escape`lalala<script>alert(1)</script>`,
+      'lalala' + '&lt;script>alert(1)&lt;/script>'
+    );
+
+    assert.equal(Html.escape`What does 😊 mean?`, 'What does 😊 mean?');
+    const output = Html.escape`<What does 😊`;
+    assert.equal(output, '&lt;What does 😊');
+    assert.equal(
+      Html.escape`<div>What does 😊 mean in text?`,
+      '&lt;div>What does 😊 mean in text?'
+    );
+
+    assert.equal(
+      Html.escape`${('lalala' + '<script>alert(1)</script>' + 'lalala').repeat(900)}`,
+      'lalala&lt;script>alert(1)&lt;/script>lalala'.repeat(900)
+    );
+    assert.equal(
+      Html.escape`${('<script>alert(1)</script>' + 'lalala').repeat(900)}`,
+      '&lt;script>alert(1)&lt;/script>lalala'.repeat(900)
+    );
+    assert.equal(
+      Html.escape`${('lalala' + '<script>alert(1)</script>').repeat(900)}`,
+      ('lalala' + '&lt;script>alert(1)&lt;/script>').repeat(900)
+    );
+
+    // the positions of the unicode codepoint are important
+    // our simd code for U16 is at 8 bytes, so we need to especially check the boundaries
+    assert.equal(
+      Html.escape`😊lalala<script>alert(1)</script>lalala`,
+      '😊lalala&lt;script>alert(1)&lt;/script>lalala'
+    );
+    assert.equal(
+      Html.escape`${'<script>😊alert(1)</script>' + 'lalala'}`,
+      '&lt;script>😊alert(1)&lt;/script>lalala'
+    );
+    assert.equal(
+      Html.escape`<script>alert(1)😊</script>lalala`,
+      '&lt;script>alert(1)😊&lt;/script>lalala'
+    );
+    assert.equal(
+      Html.escape`<script>alert(1)</script>😊lalala`,
+      '&lt;script>alert(1)&lt;/script>😊lalala'
+    );
+    assert.equal(
+      Html.escape`<script>alert(1)</script>lal😊ala`,
+      '&lt;script>alert(1)&lt;/script>lal😊ala'
+    );
+    assert.equal(
+      Html.escape`${'<script>alert(1)</script>' + 'lal😊ala'.repeat(10)}`,
+      '&lt;script>alert(1)&lt;/script>' + 'lal😊ala'.repeat(10)
+    );
+
+    for (let i = 1; i < 10; i++)
+      assert.equal(
+        Html.escape`${'<script>alert(1)</script>' + 'la😊'.repeat(i)}`,
+        '&lt;script>alert(1)&lt;/script>' + 'la😊'.repeat(i)
+      );
+
+    assert.equal(
+      Html.escape`${'la😊' + '<script>alert(1)</script>'}`,
+      'la😊' + '&lt;script>alert(1)&lt;/script>'
+    );
+    assert.equal(
+      Html.escape`${('lalala' + '<script>alert(1)</script>😊').repeat(1)}`,
+      ('lalala' + '&lt;script>alert(1)&lt;/script>😊').repeat(1)
+    );
+
+    assert.equal(Html.escape`${'😊'.repeat(100)}`, '😊'.repeat(100));
+    assert.equal(Html.escape`${'😊<'.repeat(100)}`, '😊&lt;'.repeat(100));
+    assert.equal(Html.escape`${'<😊>'.repeat(100)}`, '&lt;😊>'.repeat(100));
+    assert.equal(Html.escape`😊`, '😊');
+    assert.equal(Html.escape`😊😊`, '😊😊');
+    assert.equal(Html.escape`😊lo`, '😊lo');
+    assert.equal(Html.escape`lo😊`, 'lo😊');
+
+    assert.equal(Html.escape`${' '.repeat(32) + '😊'}`, ' '.repeat(32) + '😊');
+    assert.equal(Html.escape`${' '.repeat(32) + '😊😊'}`, ' '.repeat(32) + '😊😊');
+    assert.equal(Html.escape`${' '.repeat(32) + '😊lo'}`, ' '.repeat(32) + '😊lo');
+    assert.equal(Html.escape`${' '.repeat(32) + 'lo😊'}`, ' '.repeat(32) + 'lo😊');
+  });
+});

--- a/test/escape-tagged-func.test.tsx
+++ b/test/escape-tagged-func.test.tsx
@@ -123,8 +123,7 @@ describe('HTML Escaping', () => {
     );
 
     assert.equal(Html.escape`What does 😊 mean?`, 'What does 😊 mean?');
-    const output = Html.escape`<What does 😊`;
-    assert.equal(output, '&lt;What does 😊');
+    assert.equal(Html.escape`<What does 😊`, '&lt;What does 😊');
     assert.equal(
       Html.escape`<div>What does 😊 mean in text?`,
       '&lt;div>What does 😊 mean in text?'

--- a/test/escape-tagged-func.test.tsx
+++ b/test/escape-tagged-func.test.tsx
@@ -6,6 +6,10 @@ const unsafeTag = '<script tag="1">alert(1)</script>';
 const safeTag = Html.escape`${unsafeTag}`;
 
 describe('HTML Escaping', () => {
+  test('e is the same as escape', () => {
+    assert.equal(Html.e, Html.escape);
+  });
+
   test('escapes content', () => {
     assert.equal(<>{unsafeTag}</>, <>{unsafeTag}</>);
   });

--- a/test/escape.test.tsx
+++ b/test/escape.test.tsx
@@ -125,8 +125,8 @@ describe('HTML Escaping', () => {
     );
 
     assert.equal(Html.escapeHtml('What does 😊 mean?'), 'What does 😊 mean?');
-    const output = Html.escapeHtml('<What does 😊');
-    assert.equal(output, '&lt;What does 😊');
+
+    assert.equal(Html.escapeHtml('<What does 😊'), '&lt;What does 😊');
     assert.equal(
       Html.escapeHtml('<div>What does 😊 mean in text?'),
       '&lt;div>What does 😊 mean in text?'


### PR DESCRIPTION
It would be nice to have a tag function to escape unsafe inputs.
It improves readability in cases like this.

```tsx
function Comp(props: { something: string, times: number }) {
   return <div>{Html.escape`You have ${props.something} ${props.times} times`}</div>
}
```

instead of:

```tsx
function Comp(props: { something: string, times: number }) {
   return <div>You have {Html.escapeHtml(props.something)} {Html.escapeHtml(props.times)} times</div>
}
```
Let me know if it makes sense and if you like the implementation.
If you agree I will also make a PR to support this new way of escaping in [the ts plugin](https://github.com/kitajs/ts-html-plugin)