### PR TITLE
add register.js to sideEffects

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "funding": "https://github.com/kitajs/html?sponsor=1",
   "license": "Apache-2.0",
   "author": "arthurfiorette <npm@arthur.place>",
-  "sideEffects": false,
+  "sideEffects": ["register.js"],
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
When bundling and using the `@kitajs/html/register` module, it is removed during tree shaking. This affects Vite and esbuild (and maybe others, haven't tested), which would cause the following error to happen at runtime:

```
ReferenceError: Html is not defined
```

Adding `register.js` as a side effect will prevent bundlers from removing the module entirely when used, since it isn't a pure module.

Fixes #89 as well.

<!--
Thank you for your pull request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
