### PR TITLE
Dialog tag definition

### DIFF
--- a/jsx.d.ts
+++ b/jsx.d.ts
@@ -444,6 +444,11 @@ declare namespace JSX {
   interface HtmlDetailsTag extends HtmlTag {
     open?: undefined | boolean;
   }
+  
+  interface HtmlDialogTag extends HtmlTag {
+    open?: undefined | boolean;
+    onclose?: undefined | string;
+  }
 
   interface HtmlSelectTag extends HtmlTag {
     autofocus?: undefined | boolean;
@@ -671,7 +676,7 @@ declare namespace JSX {
     desc: HtmlSvgTag;
     details: HtmlDetailsTag;
     dfn: HtmlTag;
-    dialog: HtmlDetailsTag;
+    dialog: HtmlDialogTag;
     div: HtmlTag;
     dl: HtmlTag;
     dt: HtmlTag;


### PR DESCRIPTION
I created a `HtmlDialogTag` definition for `dialog` element.

Previously this tag was using `HtmlDetailsTag` as a definition. The `dialog` element has an attribute `onclose` to manage the `close` event according to specification. From now on, dialog definition will be complaint to the spec. 