### PR TITLE
add Picture tag and srcset to Source tag

### DIFF
--- a/.changeset/short-walls-tickle.md
+++ b/.changeset/short-walls-tickle.md
@@ -1,0 +1,5 @@
+---
+'@kitajs/html': minor
+---
+
+add Picture tag and srcset to Source tag

--- a/packages/html/jsx.d.ts
+++ b/packages/html/jsx.d.ts
@@ -411,6 +411,8 @@ declare namespace JSX {
     value?: undefined | string;
   }
 
+  interface HtmlPictureTag extends HtmlTag {}
+
   interface HtmlProgressTag extends HtmlTag {
     value?: undefined | string | number;
     max?: undefined | string | number;
@@ -469,6 +471,7 @@ declare namespace JSX {
 
   interface HtmlSourceTag extends HtmlTag {
     src?: undefined | string;
+    srcset?: undefined | string;
     type?: undefined | string;
     media?: undefined | string;
   }
@@ -780,6 +783,7 @@ declare namespace JSX {
     param: HtmlParamTag;
     path: HtmlSvgTag;
     pattern: HtmlSvgTag;
+    picture: HtmlPictureTag;
     polygon: HtmlSvgTag;
     polyline: HtmlSvgTag;
     pre: HtmlTag;


### PR DESCRIPTION
This adds the `Picture` element, as well as the `srcset` attribute to the `Source` element (used when you have the Source element within a Picture element)