### PR TITLE
Remove misleading comment about express

### DIFF
--- a/examples/suspense-server.tsx
+++ b/examples/suspense-server.tsx
@@ -47,7 +47,7 @@ http
     // Pipes it into the response
     htmlStream.pipe(response);
 
-    // If its an express or fastify server, just use
+    // If it's a fastify server just use
     // response.type('text/html; charset=utf-8').send(htmlStream);
   })
   .listen(8080, () => {


### PR DESCRIPTION
When going through the example, I realized that the docs are somewhat misleading in that if you attempt to uncomment out the code when setting up an express server, you get an error that express is trying to serialize a circular object into JSON since it doesn't know what to do with stream objects.

Uncommented it out since the express setup works fine with the uncommented out lines.

<!--
Thank you for your pull request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
