### PR TITLE
feat(runtime): export jsx and jsxs

### DIFF
--- a/.changeset/makes_tsx_happy.md
+++ b/.changeset/makes_tsx_happy.md
@@ -1,0 +1,5 @@
+---
+'@kitajs/html': minor
+---
+
+Makes [tsx](https://www.npmjs.com/package/tsx) and the underling [esbuild](https://esbuild.github.io/) ecosystem happy by exporting the `jsx` and `jsxs` from `@kitajs/html/jsx-runtime`

--- a/.changeset/makes_tsx_happy.md
+++ b/.changeset/makes_tsx_happy.md
@@ -2,4 +2,4 @@
 '@kitajs/html': minor
 ---
 
-Makes [tsx](https://www.npmjs.com/package/tsx) and the underling [esbuild](https://esbuild.github.io/) ecosystem happy by exporting the `jsx` and `jsxs` from `@kitajs/html/jsx-runtime`
+Makes [tsx](https://www.npmjs.com/package/tsx) and the underling [esbuild](https://esbuild.github.io/) ecosystem happy by exporting the `Fragment`, `jsx` and `jsxs` from `@kitajs/html/jsx-runtime`

--- a/packages/html/jsx-runtime.js
+++ b/packages/html/jsx-runtime.js
@@ -79,6 +79,7 @@ const JsxRuntime = {
 };
 
 module.exports = JsxRuntime;
-module.exports.jsx = jsx;
-module.exports.jsxs = jsx;
+exports.jsx = jsx;
+exports.jsxs = jsxs;
+exports.Fragment = Fragment;
 module.exports.default = JsxRuntime;

--- a/packages/html/jsx-runtime.js
+++ b/packages/html/jsx-runtime.js
@@ -79,4 +79,6 @@ const JsxRuntime = {
 };
 
 module.exports = JsxRuntime;
+module.exports.jsx = jsx;
+module.exports.jsxs = jsx;
 module.exports.default = JsxRuntime;


### PR DESCRIPTION
Exporting `jsx` and `jsxs` functions allows `@kitajs/html/jsx-runtime` to run in [tsx](https://www.npmjs.com/package/tsx)

Resolving
```sh
$ npx tsx index.tsx
/a/b/c/d/index.tsx:5
    <div class="stuff">
    ^

SyntaxError: The requested module '@kitajs/html/jsx-runtime' does not provide an export named 'jsx'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:134:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:217:5)
    at async ModuleLoader.import (node:internal/modules/esm/loader:323:24)
    at async loadESM (node:internal/process/esm_loader:28:7)
    at async handleMainPromise (node:internal/modules/run_main:113:12)

# And

SyntaxError: The requested module '@kitajs/html/jsx-runtime' does not provide an export named 'jsxs'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:134:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:217:5)
    at async ModuleLoader.import (node:internal/modules/esm/loader:323:24)
    at async loadESM (node:internal/process/esm_loader:28:7)
    at async handleMainPromise (node:internal/modules/run_main:113:12)

Node.js v20.12.2
```