### PR TITLE
Add `inputmode` to `HtmlTag`

### DIFF
--- a/.changeset/clever-pens-smell.md
+++ b/.changeset/clever-pens-smell.md
@@ -1,0 +1,5 @@
+---
+'@kitajs/html': patch
+---
+
+add `inputmode` attribute to Typescript typings

--- a/packages/html/jsx.d.ts
+++ b/packages/html/jsx.d.ts
@@ -41,7 +41,7 @@ declare namespace JSX {
       | 'search'
       | 'email'
       | 'url'
-      | (string & {});
+      | AnyString;
     dir?: undefined | string;
     hidden?: undefined | string | boolean;
     id?: undefined | number | string;

--- a/packages/html/jsx.d.ts
+++ b/packages/html/jsx.d.ts
@@ -31,7 +31,17 @@ declare namespace JSX {
   interface HtmlTag extends ElementChildrenAttribute, IntrinsicAttributes {
     accesskey?: undefined | string;
     contenteditable?: undefined | string;
-    inputmode?: undefined | 'none' | 'text' | 'decimal' | 'numeric' | 'tel' | 'search' | 'email' | 'url';
+    inputmode?:
+      | undefined
+      | 'none'
+      | 'text'
+      | 'decimal'
+      | 'numeric'
+      | 'tel'
+      | 'search'
+      | 'email'
+      | 'url'
+      | (string & {});
     dir?: undefined | string;
     hidden?: undefined | string | boolean;
     id?: undefined | number | string;

--- a/packages/html/jsx.d.ts
+++ b/packages/html/jsx.d.ts
@@ -31,6 +31,7 @@ declare namespace JSX {
   interface HtmlTag extends ElementChildrenAttribute, IntrinsicAttributes {
     accesskey?: undefined | string;
     contenteditable?: undefined | string;
+    inputmode?: undefined | 'none' | 'text' | 'decimal' | 'numeric' | 'tel' | 'search' | 'email' | 'url';
     dir?: undefined | string;
     hidden?: undefined | string | boolean;
     id?: undefined | number | string;


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode is missing from the types, though transpiling fine. This is a small type patch.

<!--
Thank you for your pull request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
