### PR TITLE
Revert "build(deps-dev): bump @swc-node/register from 1.9.0 to 1.9.1"

### DIFF
--- a/packages/fastify-html-plugin/package.json
+++ b/packages/fastify-html-plugin/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@fastify/formbody": "^7.4.0",
-    "@swc-node/register": "^1.9.1",
+    "@swc-node/register": "^1.9.0",
     "@swc/helpers": "^0.5.11",
     "@types/jsdom": "^21.1.6",
     "@types/node": "^20.12.7",

--- a/packages/ts-html-plugin/package.json
+++ b/packages/ts-html-plugin/package.json
@@ -32,7 +32,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "@swc-node/register": "^1.9.1",
+    "@swc-node/register": "^1.9.0",
     "@swc/helpers": "^0.5.11",
     "@types/node": "^20.12.7",
     "@types/yargs": "^17.0.32",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,8 +216,8 @@ importers:
         specifier: ^7.4.0
         version: 7.4.0
       '@swc-node/register':
-        specifier: ^1.9.1
-        version: 1.9.1(@swc/core@1.4.2(@swc/helpers@0.5.11))(@swc/types@0.1.5)(typescript@5.4.5)
+        specifier: ^1.9.0
+        version: 1.9.0(@swc/core@1.4.2(@swc/helpers@0.5.11))(@swc/types@0.1.5)(typescript@5.4.5)
       '@swc/helpers':
         specifier: ^0.5.11
         version: 0.5.11
@@ -287,8 +287,8 @@ importers:
         version: 17.7.2
     devDependencies:
       '@swc-node/register':
-        specifier: ^1.9.1
-        version: 1.9.1(@swc/core@1.4.2(@swc/helpers@0.5.11))(@swc/types@0.1.5)(typescript@5.3.3)
+        specifier: ^1.9.0
+        version: 1.9.0(@swc/core@1.4.2(@swc/helpers@0.5.11))(@swc/types@0.1.5)(typescript@5.3.3)
       '@swc/helpers':
         specifier: ^0.5.11
         version: 0.5.11
@@ -455,17 +455,17 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
-  '@swc-node/core@1.13.1':
-    resolution: {integrity: sha512-emB5l2nZsXjUEAuusqjYvWnQMLWZp6K039Mv8aq5SX1rsNM/N7DNhw1i4/DX7AyzNZ0tT+ASWyTvqEURldp5HA==}
+  '@swc-node/core@1.13.0':
+    resolution: {integrity: sha512-lFPD4nmy4ifAOVMChFjwlpXN5KQXvegqeyuzz1KQz42q1lf+cL3Qux1/GteGuZjh8HC+Rj1RdNrHpE/MCfJSTw==}
     engines: {node: '>= 10'}
     peerDependencies:
-      '@swc/core': '>= 1.4.13'
+      '@swc/core': '>= 1.3'
       '@swc/types': '>= 0.1'
 
-  '@swc-node/register@1.9.1':
-    resolution: {integrity: sha512-z//TBXJdRWXoISCXlQmVz+NMm8Qm/UvcfKiGC0tSJdfeVYf5EZkGqvk2OiRH4SIJ6OGFfS9T0YrvA2pDKzWtPA==}
+  '@swc-node/register@1.9.0':
+    resolution: {integrity: sha512-i0iYInD4q5v3xQC6bKvs0QtfUxu197CU5qKALmpxEqTYs7sIhQ7KFLe3kP+eAR4gRkJTvAgjQgrokXLN2jZrOw==}
     peerDependencies:
-      '@swc/core': '>= 1.4.13'
+      '@swc/core': '>= 1.3'
       typescript: '>= 4.3'
 
   '@swc-node/sourcemap-support@0.5.0':
@@ -2747,14 +2747,14 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
-  '@swc-node/core@1.13.1(@swc/core@1.4.2(@swc/helpers@0.5.11))(@swc/types@0.1.5)':
+  '@swc-node/core@1.13.0(@swc/core@1.4.2(@swc/helpers@0.5.11))(@swc/types@0.1.5)':
     dependencies:
       '@swc/core': 1.4.2(@swc/helpers@0.5.11)
       '@swc/types': 0.1.5
 
-  '@swc-node/register@1.9.1(@swc/core@1.4.2(@swc/helpers@0.5.11))(@swc/types@0.1.5)(typescript@5.3.3)':
+  '@swc-node/register@1.9.0(@swc/core@1.4.2(@swc/helpers@0.5.11))(@swc/types@0.1.5)(typescript@5.3.3)':
     dependencies:
-      '@swc-node/core': 1.13.1(@swc/core@1.4.2(@swc/helpers@0.5.11))(@swc/types@0.1.5)
+      '@swc-node/core': 1.13.0(@swc/core@1.4.2(@swc/helpers@0.5.11))(@swc/types@0.1.5)
       '@swc-node/sourcemap-support': 0.5.0
       '@swc/core': 1.4.2(@swc/helpers@0.5.11)
       colorette: 2.0.20
@@ -2766,9 +2766,9 @@ snapshots:
       - '@swc/types'
       - supports-color
 
-  '@swc-node/register@1.9.1(@swc/core@1.4.2(@swc/helpers@0.5.11))(@swc/types@0.1.5)(typescript@5.4.5)':
+  '@swc-node/register@1.9.0(@swc/core@1.4.2(@swc/helpers@0.5.11))(@swc/types@0.1.5)(typescript@5.4.5)':
     dependencies:
-      '@swc-node/core': 1.13.1(@swc/core@1.4.2(@swc/helpers@0.5.11))(@swc/types@0.1.5)
+      '@swc-node/core': 1.13.0(@swc/core@1.4.2(@swc/helpers@0.5.11))(@swc/types@0.1.5)
       '@swc-node/sourcemap-support': 0.5.0
       '@swc/core': 1.4.2(@swc/helpers@0.5.11)
       colorette: 2.0.20


### PR DESCRIPTION
Reverts kitajs/html#205 

v1.9.1 is buggy