### PR TITLE
Fix getting started instructions

### DIFF
--- a/packages/ts-html-plugin/README.md
+++ b/packages/ts-html-plugin/README.md
@@ -72,7 +72,7 @@ npm install @kitajs/ts-html-plugin
 
 ## Getting Started
 
-Install `@kitajs/ts-html-plugin` alongside with `@kitajs/ts-html-plugin` with your
+Install `@kitajs/html` alongside `@kitajs/ts-html-plugin` with your
 favorite package manager, and put this inside your `tsconfig.json`.
 
 ```jsonc


### PR DESCRIPTION
Replace "Install @kitajs/ts-html-plugin alongside with @kitajs/ts-html-plugin"

To "install @kitajs/html and @kitajs/ts-html-plugin"
