### PR TITLE
Add typings for the popover attribute

### DIFF
--- a/.changeset/three-plants-raise.md
+++ b/.changeset/three-plants-raise.md
@@ -1,0 +1,5 @@
+---
+'@kitajs/html': patch
+---
+
+Add `popover` attribute typings

--- a/packages/html/jsx.d.ts
+++ b/packages/html/jsx.d.ts
@@ -45,6 +45,7 @@ declare namespace JSX {
     dir?: undefined | string;
     hidden?: undefined | string | boolean;
     id?: undefined | number | string;
+    popover?: undefined | boolean | 'auto' | 'manual';
     role?: undefined | string;
     lang?: undefined | string;
     draggable?: undefined | string | boolean;

--- a/packages/html/test/attributes.test.tsx
+++ b/packages/html/test/attributes.test.tsx
@@ -55,6 +55,13 @@ describe('Attributes', () => {
     assert.equal(<div test={{}}></div>, '<div test="[object Object]"></div>');
   });
 
+  test('Popover', () => {
+    assert.equal('<div popover="auto"></div>', <div popover="auto"></div>);
+    assert.equal('<div popover="manual"></div>', <div popover="manual"></div>);
+
+    assert.equal('<div popover></div>', <div popover></div>);
+  });
+
   test('class arrays', () => {
     assert.equal(<div class="name" />, '<div class="name"></div>');
     assert.equal(<div class={['name']} />, '<div class="name"></div>');


### PR DESCRIPTION
Adds typings for the [popover](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/popover) attribute, according to the spec.

Closes #228 