### PR TITLE
FEAT/adding types for the role attribute instead of string

### DIFF
--- a/.changeset/slimy-ducks-run.md
+++ b/.changeset/slimy-ducks-run.md
@@ -2,4 +2,4 @@
 '@kitajs/html': minor
 ---
 
-adding type for the role attribute
+Added `role` attribute types

--- a/.changeset/slimy-ducks-run.md
+++ b/.changeset/slimy-ducks-run.md
@@ -1,0 +1,5 @@
+---
+'@kitajs/html': minor
+---
+
+adding type for the role attribute

--- a/packages/html/jsx.d.ts
+++ b/packages/html/jsx.d.ts
@@ -46,7 +46,7 @@ declare namespace JSX {
     hidden?: undefined | string | boolean;
     id?: undefined | number | string;
     popover?: undefined | boolean | 'auto' | 'manual';
-    role?: undefined | string;
+    role?: undefined | AriaRole;
     lang?: undefined | string;
     draggable?: undefined | string | boolean;
     spellcheck?: undefined | string | boolean;
@@ -852,3 +852,76 @@ declare namespace JSX {
     wbr: HtmlTag;
   }
 }
+
+// All the WAI-ARIA 1.1 role attribute values from https://www.w3.org/TR/wai-aria-1.1/#role_definitions
+type AriaRole =
+  | "alert"
+  | "alertdialog"
+  | "application"
+  | "article"
+  | "banner"
+  | "button"
+  | "cell"
+  | "checkbox"
+  | "columnheader"
+  | "combobox"
+  | "complementary"
+  | "contentinfo"
+  | "definition"
+  | "dialog"
+  | "directory"
+  | "document"
+  | "feed"
+  | "figure"
+  | "form"
+  | "grid"
+  | "gridcell"
+  | "group"
+  | "heading"
+  | "img"
+  | "link"
+  | "list"
+  | "listbox"
+  | "listitem"
+  | "log"
+  | "main"
+  | "marquee"
+  | "math"
+  | "menu"
+  | "menubar"
+  | "menuitem"
+  | "menuitemcheckbox"
+  | "menuitemradio"
+  | "navigation"
+  | "none"
+  | "note"
+  | "option"
+  | "presentation"
+  | "progressbar"
+  | "radio"
+  | "radiogroup"
+  | "region"
+  | "row"
+  | "rowgroup"
+  | "rowheader"
+  | "scrollbar"
+  | "search"
+  | "searchbox"
+  | "separator"
+  | "slider"
+  | "spinbutton"
+  | "status"
+  | "switch"
+  | "tab"
+  | "table"
+  | "tablist"
+  | "tabpanel"
+  | "term"
+  | "textbox"
+  | "timer"
+  | "toolbar"
+  | "tooltip"
+  | "tree"
+  | "treegrid"
+  | "treeitem"
+  | (string & {});


### PR DESCRIPTION
Adding types for the role attribute instead of raw string. The types are taken from the [w3 specs](https://www.w3.org/TR/wai-aria-1.1/#role_definitions).
