### PR TITLE
feat(html): add deprecated bgcolor attribute on <table>

### DIFF
--- a/packages/html/jsx.d.ts
+++ b/packages/html/jsx.d.ts
@@ -498,6 +498,8 @@ declare namespace JSX {
 
   interface HtmlTableTag extends HtmlTag {
     align?: undefined | 'left' | 'center' | 'right';
+    /** @deprecated */
+    bgcolor?: undefined | string;
     border?: undefined | number;
     cellpadding?: undefined | number | string;
     cellspacing?: undefined | number | string;


### PR DESCRIPTION
\following https://github.com/kitajs/html/pull/275

I'm still using `@kitajs/html` for email templates and I'm missing another deprecated attribute :)