### PR TITLE
Fix identifiers starting with 'e' considered safe

### DIFF
--- a/.changeset/few-bobcats-marry.md
+++ b/.changeset/few-bobcats-marry.md
@@ -1,0 +1,5 @@
+---
+"@kitajs/ts-html-plugin": patch
+---
+
+Fix identifiers starting with 'e' considered safe

--- a/packages/ts-html-plugin/src/util.ts
+++ b/packages/ts-html-plugin/src/util.ts
@@ -12,7 +12,7 @@ import type {
 import * as Errors from './errors';
 
 const UPPERCASE = /[A-Z]/;
-const ESCAPE_HTML_REGEX = /^(\w+\.)?(escapeHtml|e|escape)/i;
+const ESCAPE_HTML_REGEX = /^(\w+\.)?(escapeHtml|e\s*`|escape)/i;
 
 /** If the node is a JSX element or fragment */
 export function isJsx(ts: typeof TS, node: TS.Node): node is JsxElement | JsxFragment {

--- a/packages/ts-html-plugin/test/safe.test.ts
+++ b/packages/ts-html-plugin/test/safe.test.ts
@@ -6,6 +6,16 @@ it('Allow correct xss usage', async () => {
   await using server = new TSLangServer(__dirname);
 
   const diagnostics = await server.openWithDiagnostics/* tsx */ `
+    export function Test() {
+        var email = "unsafeText";
+        return <span safe>{email}</span>;
+    }
+
+    export function Test2() {
+        var eProps = { entryName: "unsafeText" };
+        return <span safe>{eProps.entryName}</span>;
+    }
+
     export default (
       <>
         <div></div>

--- a/packages/ts-html-plugin/test/unsafe-tags.test.ts
+++ b/packages/ts-html-plugin/test/unsafe-tags.test.ts
@@ -19,6 +19,9 @@ it('Detect xss prone usage', async () => {
           {['a', 'b', 'c'].map((i) => (
             <div>{i}</div>
           ))}
+          {['a', 'b', 'c'].map((e) => (
+            <div>{e}</div>
+          ))}
         </div>
         <div>{['a', 'b', 'c'].map((i) => i)}</div>
         <div>{['a', 'b', 'c'].map((safeI) => safeI)}</div>
@@ -57,15 +60,22 @@ it('Detect xss prone usage', async () => {
       category: 'error'
     },
     {
-      start: { line: 47, offset: 15 },
-      end: { line: 47, offset: 44 },
+      start: { line: 47, offset: 19 },
+      end: { line: 47, offset: 20 },
       text: Xss.message,
       code: Xss.code,
       category: 'error'
     },
     {
-      start: { line: 48, offset: 15 },
-      end: { line: 48, offset: 52 },
+      start: { line: 50, offset: 15 },
+      end: { line: 50, offset: 44 },
+      text: Xss.message,
+      code: Xss.code,
+      category: 'error'
+    },
+    {
+      start: { line: 51, offset: 15 },
+      end: { line: 51, offset: 52 },
       text: Xss.message,
       code: Xss.code,
       category: 'error'


### PR DESCRIPTION
This PR fixes issue #420. Changes `ESCAPE_HTML_REGEX` to match better and prevent false positives for diagnostic K602.

As a side note I discovered that currently, `npm run format` does not work properly out of the box after 5b662e from dependabot. Looks like `prettier-plugin-jsdoc` does not get installed properly due to version conflicts? It required me to install it manually with `pnpm i prettier-plugin-jsdoc -w` which forced prettier back down to `3.5.3` as well. Not sure what's going on there.