### PR TITLE
fix: remove deprecated "identity" for "transfer-encoding" header

### DIFF
--- a/.changeset/remove-identity-value.md
+++ b/.changeset/remove-identity-value.md
@@ -1,0 +1,5 @@
+---
+"@kitajs/fastify-html-plugin": minor
+---
+
+Remove the value `identity` from `transfer-encoding` header, as `identity` is deprecated per [RFC 7230](https://www.rfc-editor.org/rfc/rfc7230.html).

--- a/packages/fastify-html-plugin/src/html.ts
+++ b/packages/fastify-html-plugin/src/html.ts
@@ -39,7 +39,6 @@ function handleSyncHtml(htmlStr: string, reply: FastifyReply) {
 
   if (requestData === undefined) {
     return reply
-      .header('transfer-encoding', 'identity')
       .header('content-length', Buffer.byteLength(htmlStr, 'utf-8'))
       .send(htmlStr)
   }


### PR DESCRIPTION
Remove deprecated "identity" value for "transfer-encoding" header, as per RFC7230. Fixes https://github.com/kitajs/html/issues/486
