### PR TITLE
fix: exit non-zero when the CLI crashes

### DIFF
--- a/.changeset/ts-html-plugin-cli-exit-code.md
+++ b/.changeset/ts-html-plugin-cli-exit-code.md
@@ -1,0 +1,8 @@
+---
+'@kitajs/ts-html-plugin': patch
+---
+
+Make the `xss-scan` / `ts-html-plugin` CLI exit with a non-zero status code when it
+crashes. Previously an uncaught error in `main()` was only logged and the process exited
+`0`, so a crash (e.g. at startup) was reported as a passing scan in CI and verification
+hooks.

--- a/packages/ts-html-plugin/src/cli.ts
+++ b/packages/ts-html-plugin/src/cli.ts
@@ -230,4 +230,7 @@ async function main() {
   process.exit(0);
 }
 
-main().catch(console.error);
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/ts-html-plugin/test/cli-exit-code.test.ts
+++ b/packages/ts-html-plugin/test/cli-exit-code.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { it } from 'node:test';
+
+const CLI = path.join(__dirname, '..', 'dist', 'cli.js');
+const TSCONFIG = path.join(__dirname, 'tsconfig.json');
+
+it('CLI exits non-zero when main() throws (a crash must not report success)', () => {
+  const crash = `
+    process.cwd = () => {
+      throw new TypeError("Cannot read properties of undefined (reading 'readFile')");
+    };
+    require(${JSON.stringify(CLI)});
+  `;
+
+  const res = spawnSync(process.execPath, ['-e', crash], { encoding: 'utf8' });
+
+  assert.notStrictEqual(
+    res.status,
+    0,
+    `expected a non-zero exit on crash, got ${res.status}\n${res.stderr}`
+  );
+  assert.match(res.stderr, /readFile|TypeError/);
+});
+
+it('CLI still exits 0 on a clean, non-crashing run', () => {
+  const res = spawnSync(process.execPath, [CLI, '--project', TSCONFIG], {
+    encoding: 'utf8'
+  });
+
+  assert.strictEqual(res.status, 0, res.stderr);
+  assert.match(res.stdout, /No XSS vulnerabilities found/);
+});


### PR DESCRIPTION
@arthurfiorette , first of all, thank you very much for the hard work and the great software you offer to the community.

When running `@kitajs/ts-html-plugin` version 4.1.4 in the CI, I noticed that it was passing (all green), even though the script was crashing due to TypeScript compatibility issues.

This PR adds a test to reproduce the issue and includes the fix as well.

The top-level handler in `cli.ts` used `main().catch(console.error)` but left the process exit code at the default `0`.

I verified that this error does not occur in the next branch, so only this PR will be necessary.

Once again, I'm very grateful for your work!